### PR TITLE
Release: 0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
-# [0.0.1] - 2016-03-03
+# [0.0.2] - 2016-03-08
+- Initial test environment for JanusCli Release - [PR Link](https://github.com/thebeansgroup/januscli/pull/7)
+ - Test Bug Issue Title - [Fixes #6](https://github.com/thebeansgroup/januscli/issues/6)# [0.0.1] - 2016-03-03
 - OLD Initial test environment for JanusCli Release - [PR Link](https://github.com/thebeansgroup/januscli/pull/7)
  - OLD Test Bug Issue Title - [Fixes #6](https://github.com/thebeansgroup/januscli/issues/6)## Next

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "januscli",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Development toolbelt",
   "main": "es5/janus.js",
   "scripts": {


### PR DESCRIPTION
# [0.0.2] - 2016-03-08
- Initial test environment for JanusCli Release - [PR Link](https://github.com/thebeansgroup/januscli/pull/7)
  - Test Bug Issue Title - [Fixes #6](https://github.com/thebeansgroup/januscli/issues/6)
